### PR TITLE
Update the book for packet_parser 10.0.0

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,12 @@
-Here's the English version of the `README.md` tailored for the documentation book of your `packet-parser` crate:
-
----
-
 # 📘 `packet-parser` Documentation
 
-Welcome to the official documentation for the **`packet-parser`** Rust crate.
+Welcome to the official documentation for the **`packet_parser`** Rust crate.
 
-This book is designed to guide you through using the crate, understanding its module structure, decoding real network packets, adding new protocol support, benchmarking performance, and contributing to the project.
+This book explains how the crate parses network frames: its layered model, the
+data validation procedure behind every structure, how each layer is decoded, and
+how to add support for a new protocol.
+
+It currently documents **`packet_parser` 10.0.0**.
 
 ---
 
@@ -35,23 +35,30 @@ You can view the latest version of this book online here:
 
 ## 🧩 About the Crate
 
-**`packet-parser`** is a modular Rust crate built for:
+**`packet_parser`** is a modular Rust crate built for:
 
-* Parsing network frames at all levels (MAC, IP, TCP/UDP, etc.)
+* Parsing network frames at all levels (link, internet, transport, application)
+* Zero-copy decoding — the parsed flow borrows the input buffer
+* Fail-closed link-layer handling: the LINKTYPE is supplied by the caller, never guessed
+* Fail-soft handling above it: an unsupported or corrupt upper layer does not lose the layers below
 * Easily extending support for new protocols
 * Providing typed errors for each network layer
-* Offering validation and formatting tools
+
+Crate: [crates.io/crates/packet_parser](https://crates.io/crates/packet_parser) ·
+API reference: [docs.rs/packet_parser](https://docs.rs/packet_parser) ·
+Source: [github.com/Akmot9/Packet-parser](https://github.com/Akmot9/Packet-parser)
 
 ---
 
 ## 📚 What's Inside
 
-* Overview of crate architecture
-* Real-world usage examples
-* Integration with crates like `pcap` and `pnet`
-* How to write custom parsers
-* Performance benchmarks
-* Contribution guidelines and best practices
+* Getting started with `parse` and LINKTYPEs
+* What a packet is, and what a parse returns (`PacketFlow`)
+* The data validation procedure (`TryFrom`, checks, typed errors)
+* One chapter per layer: data link, internet, transport, application
+* Tunnels, owned flows and serialization
+* Performance measurement and benchmarks
+* The method for adding a new protocol
 
 ---
 
@@ -72,7 +79,3 @@ This project is licensed under the MIT License.
 ---
 
 💬 For feedback, suggestions, or issues, please visit the GitHub repository.
-
----
-
-Would you like me to generate this as a `src/README.md` or homepage section for your `mdBook` project?

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -4,11 +4,25 @@
 
 [Introduction](./introduction.md)
 
-- [ParsedPacket struct](./packet.md)
+- [Getting started](./getting_started.md)
+
+- [What is a packet?](./packet.md)
+
+- [The `PacketFlow` structure](./packet_flow.md)
+
+- [Link types](./link_types.md)
 
 - [Data validation procedure](./data_validation.md)
 
     - [Data link](./data_link.md)
-    - [Network](./network.md)
+    - [Internet](./network.md)
     - [Transport](./transport.md)
     - [Application](./application.md)
+
+- [Tunnels](./tunnels.md)
+
+- [Owned flows and serialization](./owned.md)
+
+- [Performance and benchmarks](./performance.md)
+
+- [Adding a protocol](./adding_a_protocol.md)

--- a/src/adding_a_protocol.md
+++ b/src/adding_a_protocol.md
@@ -1,0 +1,171 @@
+# Adding a protocol
+
+This chapter is the working method used in the crate itself. The reference
+document lives in the repository as
+[`METHODE_AJOUT_PROTOCOLE.md`](https://github.com/Akmot9/Packet-parser/blob/main/METHODE_AJOUT_PROTOCOLE.md);
+this is its English walkthrough.
+
+## Where the files go
+
+The library is organized **by layer**, and each protocol touches three trees:
+
+```text
+src/
+  parse/    data_link/  internet/  transport/  application/
+  errors/   data_link/  internet/  transport/  application/
+  checks/   data_link/             transport/  application/
+```
+
+For an application protocol `foo`:
+
+```text
+src/parse/application/protocols/foo.rs   # TryFrom + the struct
+src/errors/application/foo.rs            # the error enum
+src/checks/application/foo.rs            # validation and field extraction
+```
+
+If the protocol grows sub-modules, use a directory
+(`src/parse/application/protocols/foo/mod.rs`) but keep the same separation.
+Errors stay centralized in `src/errors/<layer>/<protocol>.rs`.
+
+## 1. The error type
+
+Errors must be precise and actionable. Do not use `String` as the main error when
+a dedicated variant is possible.
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error, PartialEq)]
+pub enum FooError {
+    #[error("Foo packet too short: {0} bytes")]
+    TooShort(usize),
+    #[error("Invalid Foo magic: {0:#06x}")]
+    InvalidMagic(u16),
+}
+```
+
+`TooShort(3)` and `InvalidMagic(0x4141)` say different things about the traffic.
+A single `InvalidPacket` says nothing.
+
+## 2. The checks
+
+Validation and per-field extraction go in `src/checks/`, **not inline in the
+parser**. They allocate nothing and decide nothing about structure — they answer
+yes/no and hand back field values.
+
+## 3. The parser
+
+`TryFrom<&[u8]>`, in a linear sequence: length pre-check → `extract_*` per field
+in wire order → cross-field validations → construction. Borrow (`&'a [u8]`),
+don't copy.
+
+## 4. The rustdoc
+
+The main type carries a rustdoc with a Mermaid `packet-beta` diagram of the wire
+layout, behind the `doc-diagrams` feature:
+
+```rust
+#[cfg_attr(all(doc, feature = "doc-diagrams"), aquamarine::aquamarine)]
+```
+
+## 5. Wiring it in — and the semver rule
+
+Export the module from the layer's `mod.rs`. Then stop before the reflex move:
+
+> **Do not add a variant to an exhaustive public enum.** It breaks users'
+> exhaustive `match`es, so it requires a major version.
+
+For a minor release, keep the parser reachable through its module and expose its
+name through `Application` / `PacketFlow`. When a major version *does* allow the
+new variant, add its `Display` arm in `src/displays/` at the same time.
+
+`cargo semver-checks check-release` enforces this, and the publication workflow
+runs it before any `cargo publish`.
+
+## Choosing the detection path
+
+This is the decision that matters most, and it has three answers.
+
+**Path 1 — blind probing** (`Application::try_from`). Reserved for protocols
+whose bytes identify themselves: a literal marker (`HTTP/`, `GIOP`), a tightly
+constrained binary header (DNS, NTP), or an announced length that must match the
+remaining bytes exactly (PostgreSQL).
+
+```rust
+if FooPacket::try_from(packet).is_ok() {
+    return Ok(Application { application_protocol: "Foo" });
+}
+```
+
+⚠️ **Order matters** in the probing chain. A permissive parser placed early
+captures packets belonging to another protocol. The existing ordering constraints
+are documented in comments where they apply (DHCP before SRVLOC — issue #3; MQTT
+last, because its fixed header is barely discriminant).
+
+**Path 2 — port-guarded detection**
+(`PacketFlow::parse_application_from_transport`). For weak or ambiguous
+signatures that no amount of checking can separate from another protocol. FTP,
+SMTP and NNTP responses are byte-for-byte identical (`2xx text CRLF`); DHCPv6,
+AMS, COTP and QUIC short headers have under-constrained headers; mDNS shares the
+DNS format with relaxed validation. The standard port is a guard rail **in
+addition to** the parser's checks, never in their place.
+
+**Path 3 — strong signature with a transport constraint.** The protocol
+identifies itself well enough to be recognized off its standard port, but is only
+defined over one transport. S7Comm takes this path: the full TPKT + COTP-DT + S7
+envelope allows probing on any TCP port, while the same bytes over UDP must never
+produce the S7Comm label. Test the standard port, a non-standard port, and a
+forbidden transport explicitly.
+
+**Decision criterion:** if a valid payload of your protocol can also be a valid
+payload of an already-detected protocol — or of arbitrary text — blind probing is
+forbidden. Use a port guard and document why in a comment. For a text protocol,
+also ask whether a seemingly distinctive command can appear in another protocol's
+free-form body. Without session state, that case forces a port guard too.
+
+## 6. Tests
+
+Unit tests near the parser and the checks, covering valid **and** invalid cases.
+
+Beyond that, two kinds carry most of the weight:
+
+- **Golden tests on real frames**, with the source pcap cited in a comment. Any
+  synthetic fixture is explicitly identified as synthetic.
+- **A non-empty negative corpus** for every new detection, pinned by expected
+  frame numbers or a deterministic fingerprint — otherwise a false positive can
+  hide a false negative.
+
+Fuzz targets for the protocol need at least one structured valid seed and must
+assert the transport and classification invariants.
+
+## 7. Checklist before commit
+
+- `TryFrom<&[u8]>` follows the linear sequence: length pre-check, `extract_*` per
+  field in wire order, cross-field validations, construction.
+- Errors are in a dedicated file and use `thiserror::Error`.
+- Validation and extraction live under `src/checks` — no inline validation in the
+  parser.
+- The main type has a rustdoc with a Mermaid `packet-beta` diagram.
+- The relevant `mod.rs` files export the new module.
+- Public-API semver compatibility is preserved; a variant is added to an
+  exhaustive public enum only in a major version, with its `Display` arm.
+- The detection path is chosen **and justified**.
+- Tests cover valid and invalid cases.
+- At least one golden test on a real frame exists, with its source pcap cited.
+- Every new detection is verified against a non-empty negative corpus.
+- The affected fuzz targets have a structured seed and check their invariants.
+- The protocol lists in `README.md` and `README-fr.md` are updated — and, if this
+  book documents the layer, its chapter too.
+
+## Useful commands
+
+```bash
+cargo fmt --all -- --check
+cargo test --workspace --all-features
+cargo clippy --workspace --all-targets --all-features -- -D warnings
+cargo +nightly fuzz build
+cargo audit
+cargo deny check --hide-inclusion-graph
+cargo semver-checks check-release   # compares the public API to the last published version
+```

--- a/src/application.md
+++ b/src/application.md
@@ -1,1 +1,115 @@
 # Application
+
+## A classification, not a decode
+
+This layer is the one that surprises people, so it is worth stating plainly:
+
+```rust
+pub struct Application {
+    pub application_protocol: &'static str,
+}
+```
+
+That is the whole structure. In a `PacketFlow`, the application layer reports
+**which protocol was detected**, not a parsed message. It is a `&'static str`,
+not even an allocation.
+
+The detailed parsers exist — they are what performs the detection — but their
+output is not carried in the flow. When you want the decoded message, call the
+parser directly:
+
+```rust
+use packet_parser::parse::application::protocols::dns::DnsPacket;
+
+let dns = DnsPacket::try_from(transport_payload)?;
+```
+
+The rationale is cost. A flow matrix over a million packets wants a label, not a
+million allocated DNS trees. Paying for the deep parse is the caller's decision,
+made per packet.
+
+## Supported protocols
+
+Parser modules under `packet_parser::parse::application::protocols`:
+
+| | | |
+| --- | --- | --- |
+| DNS (and mDNS) | TLS | SNMP |
+| NTP | DHCP | DHCPv6 |
+| HTTP | MQTT | PostgreSQL |
+| FTP | SMTP | NNTP |
+| SSH | Modbus TCP | EtherNet/IP |
+| OPC UA | S7Comm | COTP |
+| AMS | GIOP | SRVLOC |
+| QUIC | Bitcoin | |
+
+A few notes on individual ones:
+
+- **mDNS** is distinct from classic DNS (`DnsPacket::try_from_mdns`): it must
+  accept announcements with no question, and it decodes the QU and cache-flush
+  bits.
+- **SSH** is the identification string only. Everything after the version
+  exchange is encrypted, so a stateless parser labels the banner frames and
+  nothing else. Claiming "SSH" on the encrypted remainder would be a guess.
+- **S7Comm** wins over the generic COTP label when both match, since S7Comm is a
+  COTP DT user. TPKT is decoded before COTP on TCP/102.
+
+## Detection is best-effort — and that is a design constraint
+
+There is no field in a TCP segment that says "this is HTTP". Detection is
+signature matching, and signature matching has false positives. The crate handles
+this by splitting protocols into two regimes.
+
+### Strong signatures: probed on content
+
+A protocol with a distinctive, structurally validated header can be detected on
+any port. TLS records, QUIC long headers, DNS, S7Comm over TCP — a full parse
+that succeeds on these is evidence, not a coincidence.
+
+### Weak signatures: parser-validated *and* port-restricted
+
+FTP, SMTP and NNTP are line-oriented ASCII. `PASV`, `PORT`, `220 ` — these
+strings occur inside the *body* of other text protocols. An SMTP message
+quoting an FTP session is not an FTP session.
+
+So detection of these in `PacketFlow` requires both a successful parse **and**
+the protocol's plaintext control port:
+
+| Protocol | Required TCP port |
+| --- | --- |
+| FTP | 21 |
+| SMTP | 25, 587 |
+| NNTP | 119 |
+
+Payloads on other ports are simply not labelled as these protocols. SNMP and
+DHCPv6 are guarded the same way on their UDP ports.
+
+This is not a contradiction of the "parse each layer independently" rule from
+[the packet chapter](./packet.md). The port never *causes* a protocol to be
+claimed — the parser still has to accept the bytes. The port only vetoes claims
+that would otherwise be plausible noise.
+
+### Implicit TLS ports
+
+A complete TLS record on an implicit-TLS port such as 465, 563 or 990 is reported
+as **TLS**, not as the tunnelled protocol. That is the honest answer: the SMTP or
+NNTP payload is encrypted and this crate does not see it. To inspect externally
+decrypted application data, call the detailed protocol parser directly on the
+plaintext.
+
+### Guards that come from the layers below
+
+Two rules from earlier chapters do most of the work in preventing nonsense here:
+
+- **ICMP keeps `payload: None`** — so quoted datagrams are never submitted to
+  application detection ([Transport](./transport.md)).
+- **Fragments set `payload_protocol: None`** — so no application detection runs
+  on a partial datagram ([Internet](./network.md)).
+
+## Where detection happens
+
+`PacketFlow` builds the application layer from the transport payload, applying
+the port guards described above. `Application::try_from(&[u8])` is the raw
+probing entry point: given a bare payload with no context, it tries the parsers
+and returns the first match. It has no port information, so it cannot apply the
+weak-signature guards — use it only when you know what you are handing it.

--- a/src/crate_struct.md
+++ b/src/crate_struct.md
@@ -1,3 +1,0 @@
-# Packet struct
-
-the Packet Struct is composed

--- a/src/data_link.md
+++ b/src/data_link.md
@@ -1,7 +1,7 @@
-# Chapter 1
+# Data link
 
-### **Parsing the Data Link Layer from a Raw Packet**
-Understanding how to parse the **Data Link Layer** from raw packets is a crucial step in network packet analysis. The Data Link Layer provides essential information such as **MAC addresses, Ethertype, and payload extraction**. This section explains the approach I took to implement the `DataLink` structure parsing.
+### **Parsing the link layer from a raw packet**
+Understanding how to parse the **link layer** from raw packets is a crucial step in network packet analysis. It provides essential information such as **MAC addresses, Ethertype, and payload extraction**. This section explains the approach I took to implement the `DataLink` structure parsing, and how it later generalized to the non-Ethernet capture formats.
 
 ---
 
@@ -16,6 +16,16 @@ The main components are:
 3. **Ethertype** (2 bytes) – Determines the protocol encapsulated in the payload.
 4. **Payload** (Variable length) – Contains the encapsulated network-layer packet (ipv4, arp, etc ...).
 
+```rust
+pub struct DataLink<'a> {
+    pub destination_mac: MacAddress,
+    pub source_mac: MacAddress,
+    pub vlan: Option<VlanTag>,
+    pub ethertype: Ethertype,
+    pub payload: &'a [u8],
+}
+```
+
 ---
 
 ### **Breaking Down the MAC Address Structure**
@@ -27,6 +37,9 @@ To parse MAC addresses correctly, we need to ensure that:
 **MAC Address Structure:**
 ![Mac Struct Overview](images/datalink/mac_struct.png)
 
+`MacAddress` is a `[u8; 6]` newtype, not a `String`. It only becomes
+`"aa:bb:cc:dd:ee:ff"` when displayed or serialized, so a parsed frame carries six
+bytes instead of a heap allocation. OUI resolution is internal to the crate.
 
 ---
 
@@ -38,6 +51,10 @@ The **Ethertype** is a 2-byte field that defines the **type of payload** carried
 - Map **well-known Ethertypes** (IPv4, IPv6, ARP, etc.).
 - Allow handling of **unknown protocols** without failure.
 
+`Ethertype` is a `u16` newtype for the same reason `LinkType` is: an unknown
+value is **kept**, not collapsed into an `Unknown` variant. `static_name()`
+returns the well-known name without allocating, or `None`.
+
 📌 **Example of Well-Known Ethertypes (IEEE Standard Correspondence Table):**
 
 | Ethertype (Hex) | Protocol |
@@ -46,6 +63,21 @@ The **Ethertype** is a 2-byte field that defines the **type of payload** carried
 | `0x86DD` | IPv6 |
 | `0x0806` | ARP |
 | `0x8100` | VLAN Tagging |
+
+### **VLAN tags (802.1Q)**
+
+An `0x8100` EtherType is not a protocol, it is a 4-byte insertion before the real
+one. The tag is decoded into its own structure and the *inner* EtherType is what
+drives L3 parsing:
+
+```rust
+pub struct VlanTag {
+    pub id: u16,              // 12 bits, 0–4095
+    pub pcp: u8,              // Priority Code Point, 0–7
+    pub dei: bool,            // Drop Eligible Indicator
+    pub inner_ethertype: Ethertype,
+}
+```
 
 ---
 
@@ -59,12 +91,15 @@ While parsing, I implemented **validations** to ensure the raw packet is coheren
 
 📌 **Validations Performed:**
 
-✅ **Packet Minimum Length Check** – Ensure the packet is at least **14 bytes** (`MAC_DST + MAC_SRC + Ethertype`).  
-✅ **Macaddress Minimum Length Check** – at least **6 bytes**.  
-✅ **etherthype ceherence** – if ethertype is ipv4 or ipv6 the payload can't be empty.  
+✅ **Packet Minimum Length Check** – Ensure the packet is at least **14 bytes** (`MAC_DST + MAC_SRC + Ethertype`).
+✅ **Macaddress Minimum Length Check** – at least **6 bytes**.
+✅ **etherthype ceherence** – if ethertype is ipv4 or ipv6 the payload can't be empty.
 
-
-
+⚠️ Note what is **not** on that list: nothing verifies that the bytes *are*
+Ethernet. There is no such check to write — any 14 bytes form a syntactically
+valid Ethernet header. This is precisely why `DataLink::try_from(&[u8])` is a
+compatibility shortcut and the canonical entry point takes an explicit LINKTYPE.
+See [Link types](./link_types.md).
 
 ### **Structuring the Parsed Packet**
 After extracting all components, I structured the parsed frame in a clear format. This makes it easier to **analyze, debug, and process packets** dynamically.
@@ -78,17 +113,59 @@ After extracting all components, I structured the parsed frame in a clear format
 
 ---
 
+## **Beyond Ethernet: the `LinkLayer` wrapper**
+
+Ethernet was the original — and for a while, only — assumption. Captures broke
+it: `tcpdump -i any` yields Linux cooked frames, tunnels yield 802.11, some
+sources yield bare IP with no link header at all.
+
+Rather than teach `DataLink` to be five things, the frame types stay separate and
+a wrapper carries them along with the LINKTYPE they came from:
+
+```rust
+pub struct LinkLayer<'a> {
+    link_type: LinkType,
+    network_protocol: NetworkProtocol,
+    network_payload: &'a [u8],
+    kind: LinkLayerKind<'a>,
+}
+```
+
+Two things are common to every format and therefore exposed generically:
+
+- `network_protocol()` → `NetworkProtocol` (`Ipv4`, `Ipv6`, `Arp`, `Profinet`,
+  `Other(u16)`) — a format-neutral answer to "what is next?", because RAW and SLL
+  have no EtherType to give.
+- `network_payload()` → the borrowed L3 slice.
+
+Everything format-specific goes through an explicit, fallible accessor:
+
+```rust
+match flow.data_link.kind() {
+    LinkLayerKind::Ethernet(eth)  => println!("{} -> {}", eth.source_mac, eth.destination_mac),
+    LinkLayerKind::LinuxSll(sll)  => println!("cooked v1, arphrd={:?}", sll),
+    LinkLayerKind::LinuxSll2(s2)  => println!("cooked v2, ifindex kept"),
+    LinkLayerKind::RawIp(_)       => println!("no link header"),
+    LinkLayerKind::Ieee80211(_)   => println!("wireless frame"),
+}
+```
+
+There is deliberately **no** `source_mac()` on `LinkLayer`. A cooked-capture
+frame has a source address of a declared length that may not be a MAC, and a RAW
+IP packet has none at all — an accessor returning something plausible for those
+would be inventing data. The per-format notes for SLL v1, SLL v2 and RAW IP are
+in [Link types](./link_types.md).
+
+---
+
 ## **🚀 Conclusion**
-Parsing the **Data Link Layer** requires **careful validation** and **structured extraction**. By following a modular approach:
+Parsing the link layer requires **careful validation** and **structured extraction**. By following a modular approach:
 - **MAC addresses** are extracted safely.
 - **Ethertype** is correctly mapped.
 - **Payload validation** prevents out-of-bounds errors.
-- The structure is **extensible** for future protocols.
+- The structure is **extensible** for future formats — which is exactly what
+  happened when SLL, SLL2, RAW and 802.11 arrived.
 
 This foundational parsing is crucial for **higher-layer analysis**, such as decoding **IP, TCP, UDP, and application-level protocols**.
 
-🚀 **Next Steps:** Exploring **network-layer parsing (IPv4/IPv6)**!
-
-
-
-
+🚀 **Next Steps:** Exploring **internet-layer parsing (IPv4/IPv6)**!

--- a/src/data_validation.md
+++ b/src/data_validation.md
@@ -2,6 +2,95 @@
 
 ![data_validation](images/TryFrom_algo.png)
 
-When we receive a packet, we use TryFrom to apply several validation steps to it.
+When we receive a packet, we use `TryFrom` to apply several validation steps to it.
 If the validations succeed, the function returns a structured representation of the packet or a part of it.
-If the validations fail, it returns a custom error, implemented using the [thiserror crate](https://crates.io/crates/thiserror). 
+If the validations fail, it returns a custom error, implemented using the [thiserror crate](https://crates.io/crates/thiserror).
+
+Every protocol in the crate follows this same shape, and the module layout
+mirrors it:
+
+| Module | Responsibility |
+| --- | --- |
+| `src/errors/<layer>/<proto>.rs` | The protocol's error enum (`thiserror`) |
+| `src/checks/<layer>/<proto>.rs` | Pure validation functions — no allocation, no decoding |
+| `src/parse/<layer>/protocols/<proto>.rs` | The `TryFrom<&[u8]>` implementation and the struct it builds |
+| `src/displays/<layer>/...` | `Display` implementations, kept out of the parsers |
+
+Checks come first, extraction second. A parser that interleaves the two ends up
+half-building a structure it then has to throw away, and — worse — ends up with
+validation rules that only exist implicitly, in the order the fields happen to be
+read.
+
+## Validate, then extract
+
+```rust
+impl<'a> TryFrom<&'a [u8]> for SomePacket<'a> {
+    type Error = SomeError;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Self, Self::Error> {
+        // 1. length and structural checks
+        check_min_length(bytes)?;
+        // 2. field coherence checks
+        check_reserved_bits(bytes)?;
+        // 3. only now, build the structure — borrowing, not copying
+        Ok(SomePacket { /* … */ })
+    }
+}
+```
+
+Each step returns a **specific** error variant. `PacketTooShort(3)` and
+`InvalidReservedField` tell you different things about the traffic; a single
+`InvalidPacket` variant would tell you nothing.
+
+## Probing versus dispatching
+
+There are two ways to reach a protocol's `TryFrom`, and they are not
+interchangeable.
+
+**Dispatching** — the layer below announced what comes next, so we call exactly
+one parser:
+
+```rust
+Internet::try_from_parts(ethertype, payload)
+Transport::try_from_parts(payload_protocol, payload)
+```
+
+**Probing** — nothing announced anything, so we try parsers until one accepts:
+
+```rust
+Internet::try_from(payload)
+Application::try_from(payload)
+```
+
+Dispatching is strictly more informative. When the EtherType says IPv4 and the
+IPv4 parser refuses the bytes, we know the packet is *corrupt*. When we probe and
+every parser refuses, we cannot tell corruption from an unsupported protocol —
+the answer is the same "nothing matched".
+
+That is exactly the difference between the two `None` cases described in
+[the `PacketFlow` chapter](./packet_flow.md), and it is why the internal parsing
+path always dispatches when the information is available. The probing entry
+points remain public because they are useful when you hand the crate a bare
+payload with no context — a TCP payload you already extracted, for instance.
+
+## Fail-soft is decided one level up
+
+The parsers themselves are strict: `TryFrom` returns `Err` on anything it cannot
+justify. Graceful degradation is not implemented inside them, it is implemented
+by `PacketFlow`, which catches the error and turns it into
+`corrupted: Some(CorruptedLayer { .. })`.
+
+Keeping the two separate means a parser used on its own stays honest — it tells
+you the bytes are wrong — while a full-packet parse stays usable on real,
+messy traffic.
+
+## Zero-copy is part of the contract
+
+Validation must not allocate to decide. Parsers borrow from the input buffer
+(`&'a [u8]`) and store slices, not `Vec`s, for the L2/L3/L4 path. A few
+application parsers (DNS name decompression, HTTP, SNMP) genuinely need to
+allocate, and tunnel recursion boxes the inner flow — those are the documented
+exceptions, not the norm.
+
+The next four chapters walk through the layers in order: what each one validates,
+what it extracts, and what it hands to the layer above.

--- a/src/getting_started.md
+++ b/src/getting_started.md
@@ -1,0 +1,118 @@
+# Getting started
+
+## Installation
+
+```toml
+[dependencies]
+packet_parser = "10.0.0"
+```
+
+The examples in this book decode hexadecimal dumps, so they also use `hex`:
+
+```toml
+[dependencies]
+hex = "0.4"
+packet_parser = "10.0.0"
+```
+
+## Parsing one packet
+
+`parse` is the entry point. It takes two things: the **LINKTYPE the capture
+declares**, and **exactly one packet**, without any PCAP or PCAPNG record
+header.
+
+```rust
+use packet_parser::{LinkType, parse};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let raw = hex::decode(
+        "feaa81e86d1efeaa818ec864080045500034000000003d06206b36e6700d\
+         ac140a0201bbc1087d7f02aa4e2b998e80100081748300000101080a9373\
+         c9c207ef14e3",
+    )?;
+
+    // Always pass the LINKTYPE the capture declares.
+    let flow = parse(LinkType::ETHERNET, &raw)?;
+
+    println!("L2: {}", flow.data_link);
+
+    if let Some(internet) = &flow.internet {
+        println!(
+            "L3: {} {:?} -> {:?}",
+            internet.protocol_name, internet.source, internet.destination
+        );
+    }
+
+    if let Some(transport) = &flow.transport {
+        println!(
+            "L4: {:?} {:?} -> {:?}",
+            transport.protocol, transport.source_port, transport.destination_port
+        );
+    }
+
+    if let Some(application) = &flow.application {
+        println!("L7: {}", application.application_protocol);
+    }
+
+    Ok(())
+}
+```
+
+Note the shape of the code: the link layer is read directly, everything above it
+is an `Option`. That is not defensive style — it is the actual contract, and
+[the `PacketFlow` chapter](./packet_flow.md) explains why.
+
+## Rejecting a capture before reading it
+
+`is_supported` answers whether this build has a decoder for a LINKTYPE. Ask
+before iterating over thousands of packets, not once per packet:
+
+```rust
+use packet_parser::{LinkType, is_supported, parse};
+
+let link_type = LinkType::ETHERNET;
+if !is_supported(link_type) {
+    return Err(format!("unsupported LINKTYPE {}", link_type).into());
+}
+
+let flow = parse(link_type, packet_bytes)?;
+```
+
+## The main API in one table
+
+| Need | API |
+| --- | --- |
+| Check whether a link decoder exists | `is_supported(LinkType)` |
+| **Parse a packet (canonical)** | `parse(LinkType, &[u8])` |
+| Parse Ethernet, compat shortcut — assumes Ethernet, [see the warning](./link_types.md#the-ethernet-shortcut-is-a-trap) | `PacketFlow::try_from(&[u8])` |
+| Parse only Ethernet/VLAN — assumes Ethernet | `DataLink::try_from(&[u8])` |
+| Parse only L3 | `Internet::try_from(&[u8])` |
+| Parse only L4 | `Transport::try_from(&[u8])` or `Transport::try_from_parts(...)` |
+| Detach the result from the original buffer | `flow.to_owned()` |
+| Iterate over encapsulated flows | `flow.flatten()` |
+| Measure an explicit LINKTYPE | `parse_timed(...)`, feature `parse_timing` |
+| Measure Ethernet through the compat API | `PacketFlow::try_from_timed(...)`, feature `parse_timing` |
+
+## Runnable examples
+
+The crate repository ships several entry points under `examples/`:
+
+```bash
+cargo run --example parse_tcp
+cargo run --example parse_hex_dump
+cargo run --example pars_quic
+cargo run --example parse_pgadm
+```
+
+The binaries that read PCAP files through the `pcap` crate need the system
+libpcap development package (`sudo apt-get install libpcap-dev` on
+Debian/Ubuntu).
+
+## Checks before a commit
+
+```bash
+cargo fmt -- --check
+cargo clippy --all-targets -- -D warnings
+cargo test --all-features
+cargo build --release
+```

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -3,33 +3,59 @@
 
 <p align="center"><img src="images/packet_parser.png" alt="The crate Logo" /></p>
 
-**Packet Parser** is a Rust library designed for parsing network frames.  
+**Packet Parser** is a Rust library designed for parsing network frames.
 This book explains how I developed it, its internal architecture, so you can contribute.
 
 ## Key Features
 
-- **Multi-layer support**: Supports parsing of data link, network, transport, and application layers.
-- **Data validation**: Built-in mechanisms to ensure packet integrity.
-- **Precise error management**: Each layer has its own dedicated error types for better debugging.
-- **Optimized performance**: Integrated benchmarking using Criterion.
-- **Extensibility**: Modular architecture that allows easy addition of new protocols.
+- **Multi-layer support**: link, internet, transport and application layers.
+- **Zero-copy**: `PacketFlow` borrows the input buffer — no payload is copied
+  for L2/L3/L4. Some application parsers (DNS, HTTP, SNMP…) and tunnel
+  recursion do allocate.
+- **Fail-closed on the link layer**: the LINKTYPE is supplied by the caller,
+  never guessed from the bytes. An unsupported one is an error, not a lie.
+- **Fail-soft above it**: an unsupported or malformed upper layer leaves that
+  layer `None` instead of failing the whole parse — and says which one broke.
+- **Precise error management**: each layer has its own dedicated error types,
+  built with [`thiserror`](https://crates.io/crates/thiserror).
+- **Tunnels**: one wire packet can yield several flow levels (`inner`).
+- **Optimized performance**: benchmarked per version, with an optional
+  per-layer timing feature.
+- **Extensibility**: modular architecture that allows easy addition of new
+  protocols — see [Adding a protocol](./adding_a_protocol.md).
 
 ## Purpose of this crate
 
-The goal of this crate is to provide a function that transforms a Packet or a list of bytes to be more precice into any type of packet structure or an error if you are just getting fooled and reciev uncohrent bytes.   
+The goal of this crate is to provide a function that transforms a packet — a
+list of bytes, to be precise — into a structured representation of that packet,
+or into an error if you are just getting fooled and received incoherent bytes.
 
-- It is **not restricted to a specific layer**: You can pass a TCP payload, and it will return an HTTP, TLS, NTP, or other applicable protocol structure.  
-- You can provide a **full network packet**, and it will return a structured representation containing **data link, network, transport, and application layers**.
+- It is **not restricted to a specific layer**: you can pass a TCP payload, and
+  it will tell you it is HTTP, TLS, NTP, or another applicable protocol.
+- You can provide a **full network packet**, and it will return a structured
+  representation containing **data link, internet, transport and application
+  layers**.
 
-To explain how i made this crate les dive into packet parsing my passion.
+## What changed since the first version of this book
 
-have to know what do i call a packet because thats what we are stating from.
+The book originally described a `ParsedPacket` structure that either parsed the
+whole packet or failed. Real captures killed that design. Two things replaced it:
 
-then we'll se how i parse this packet:
+- `ParsedPacket` became [`PacketFlow`](./packet_flow.md), which is *partial by
+  construction*: only the link layer is mandatory, and the others are `Option`s.
+- The link layer stopped being "Ethernet, obviously". The caller now passes the
+  capture's [LINKTYPE](./link_types.md) to `parse`, because a capture on the
+  Linux `any` interface is not Ethernet and silently pretending otherwise
+  produces MAC addresses that never existed on the wire.
 
-Parsing procedure
+## Roadmap of this book
 
-now that we know how to parse packet. let's see how we retrieve the **network layer structure** as an example, so you can understand the **data validation procedure** I use for every struct in this crate: `TryFrom::`.  
+To explain how I made this crate, let's dive into packet parsing — my passion.
 
+First, [what do I call a packet](./packet.md), because that is what we start
+from. Then, [what a parse returns](./packet_flow.md) and
+[how the link type is chosen](./link_types.md).
 
-
+Then we look at how we retrieve each layer's structure, so you can understand
+the **data validation procedure** I use for every struct in this crate:
+`TryFrom`.

--- a/src/link_types.md
+++ b/src/link_types.md
@@ -1,0 +1,155 @@
+# Link types
+
+Everything else in this crate degrades gracefully. The link layer does not, and
+this chapter explains why that asymmetry exists.
+
+## The LINKTYPE comes from the caller
+
+```rust
+pub struct LinkType(pub u32);
+```
+
+`LinkType` is a transparent wrapper over the canonical `LINKTYPE_*` numbering
+stored in capture files — not an enum. Unknown values are **preserved as-is**
+instead of being collapsed into an `Unknown` variant, so a value this build does
+not decode still round-trips through your tooling.
+
+The named constants:
+
+| Constant | Value |
+| --- | ---: |
+| `LinkType::ETHERNET` | 1 |
+| `LinkType::RAW` | 101 |
+| `LinkType::IEEE802_11` | 105 |
+| `LinkType::LINUX_SLL` | 113 |
+| `LinkType::BLUETOOTH_HCI_H4_WITH_PHDR` | 201 |
+| `LinkType::IPV4` | 228 |
+| `LinkType::IPV6` | 229 |
+| `LinkType::LINUX_SLL2` | 276 |
+
+Two caller responsibilities follow from keeping the crate independent of PCAP,
+PCAPNG and libpcap:
+
+- A **live capture** hands you `DLT_*` values. Where their numeric value differs
+  from the `LINKTYPE_*` value, the adapter normalizes them first.
+- For **PCAPNG**, the reader resolves the interface referenced by each packet and
+  passes that interface's LINKTYPE — a single file can mix several.
+
+And `parse` takes **exactly one packet**, without the PCAP/PCAPNG record header.
+
+## What is supported
+
+| LINKTYPE | Value | Decoder status |
+| --- | ---: | --- |
+| Ethernet | 1 | Supported |
+| RAW IP | 101 | Supported for IPv4 and IPv6 |
+| Native IEEE 802.11 | 105 | Modelled for CAPWAP inner flows; top-level decoder not yet supported |
+| Linux SLL v1 | 113 | Supported |
+| Bluetooth H4 with pseudo-header | 201 | Identified, explicitly unsupported |
+| Linux SLL v2 | 276 | Supported |
+| Any other value | Preserved as-is | `ParseError::UnsupportedLinkType` |
+
+An unsupported LINKTYPE is rejected **before any packet byte is decoded**. Check
+it once per capture with `is_supported`, not once per packet.
+
+## The Ethernet shortcut is a trap
+
+`PacketFlow::try_from(&[u8])` and `DataLink::try_from(&[u8])` take a bare byte
+slice and **assume Ethernet**. They are kept for compatibility and will be
+removed in a future major release.
+
+The problem is not that they can fail. It is that they **cannot**:
+
+> Feed a `LINKTYPE_LINUX_SLL` frame — what a capture on the Linux `any`
+> interface yields — to the shortcut, and its 16 cooked-header bytes are
+> reinterpreted as an Ethernet header. The call returns `Ok`, with **fabricated
+> MAC addresses**, `internet: None` and `corrupted: None`. Nothing signals the
+> mistake, and a flow matrix built from it fills up with addresses that never
+> existed on the wire.
+
+There is no plausibility check: any buffer of at least 14 bytes is a valid
+Ethernet header as far as that code path is concerned. Reach for it only when the
+capture is known to be Ethernet; otherwise pass the LINKTYPE the capture
+declares.
+
+This is the reason the link layer is fail-closed while everything above it is
+fail-soft. A wrong guess above L2 produces a `None` you can see. A wrong guess at
+L2 produces confident, plausible, wrong data.
+
+## A generic link layer
+
+Every parsed flow carries a `LinkLayer`, not an Ethernet frame:
+
+```rust
+pub enum LinkLayerKind<'a> {
+    Ethernet(DataLink<'a>),
+    RawIp(RawIpLink<'a>),
+    LinuxSll(LinuxSllLink<'a>),
+    LinuxSll2(LinuxSll2Link<'a>),
+    Ieee80211(Ieee80211Link<'a>),
+}
+```
+
+The common accessors do not assume Ethernet:
+
+```rust
+println!("LINKTYPE={}", flow.data_link.link_type());
+println!("next={:?}", flow.data_link.network_protocol());
+
+if let Some(ethernet) = flow.data_link.as_ethernet() {
+    println!("{} -> {}", ethernet.source_mac, ethernet.destination_mac);
+}
+```
+
+`network_payload()` returns the borrowed L3 slice, and `network_protocol()`
+returns a format-neutral `NetworkProtocol` (`Ipv4`, `Ipv6`, `Arp`, `Profinet`,
+`Other(u16)`) rather than an EtherType — RAW IP and SLL have no EtherType to
+give.
+
+Format-specific views are **explicit**: `as_ethernet()`, `as_raw_ip()`,
+`as_linux_sll()`, `as_linux_sll2()`, `as_ieee80211()`. Each returns an `Option`,
+so RAW and both SLL formats cannot silently manufacture Ethernet fields.
+
+## Per-format notes
+
+### RAW IP
+
+An empty packet, or a version nibble other than 4 or 6, returns a structured
+`InvalidLinkLayer(LinkLayerError)` — this is genuinely a link-layer failure.
+
+Once IPv4 or IPv6 *is* identified, an invalid or truncated IP header is no longer
+a link-layer problem: it becomes a successful partial flow with
+`corrupted: Internet`, and the link layer and its accounting are preserved.
+
+### Linux SLL v1 (113)
+
+Decodes its 16-byte cooked header in network byte order and keeps the packet
+type, the raw ARPHRD hardware type, the declared address length, the available
+source-address bytes and the protocol value.
+
+Unknown numeric values are preserved rather than rejected. An address longer than
+the eight-byte wire slot is **reported as truncated** (`address_is_truncated()`),
+not treated as a parse failure.
+
+Use the canonical `LinkType::LINUX_SLL` (113). The value 25 that some Wireshark
+fields display is an internal WTAP encapsulation identifier, not a LINKTYPE.
+
+### Linux SLL v2 (276)
+
+Independently decodes its own 20-byte header — it is not v1 with extra fields —
+and additionally keeps the numeric capture-machine interface index and the
+reserved-MBZ field.
+
+A non-zero reserved value is preserved and reported by `reserved_is_zero()`
+rather than discarding an otherwise decodable packet, matching Tshark's tolerant
+dissection. Interface *names* are not resolved: they belong to the capture
+machine, not to the packet.
+
+Use the canonical `LinkType::LINUX_SLL2` (276); Wireshark's current internal WTAP
+encapsulation identifier for this format is 210.
+
+### IEEE 802.11 (105)
+
+The 802.11 link model exists and is used for the inner frames of
+[CAPWAP tunnels](./tunnels.md), but it is not yet wired as a top-level LINKTYPE
+decoder.

--- a/src/network.md
+++ b/src/network.md
@@ -101,9 +101,17 @@ pub enum IpType {
 ```
 
 This is cheap at parse time and expensive to redo later, which is why it is done
-here rather than left to callers. It is also what lets you separate
-"machine talking to the internet" from "machine talking to its own subnet"
-without a second pass.
+here rather than left to callers: a routable public address, an RFC 1918 one and
+a multicast group get told apart in one pass instead of by a second walk over
+every flow.
+
+⚠️ **This is address-category classification, not topology.** `IpType` looks at
+the address alone and never compares it with the capture interface's address and
+prefix, so it cannot answer "is this endpoint on my subnet?". A `Private`
+destination may sit on another routed subnet, and a `Public` one may be directly
+attached. Subnet membership requires the interface address and prefix, which are
+properties of the capture machine — not of the packet — and are therefore
+outside what this crate can see.
 
 ## Fragmentation: the deliberate `None`
 

--- a/src/network.md
+++ b/src/network.md
@@ -1,1 +1,142 @@
-# Network
+# Internet
+
+The internet layer (L3) is parsed from the link layer's `network_payload()`,
+dispatching on the `NetworkProtocol` the link layer announced.
+
+## The `Internet` structure
+
+```rust
+pub struct Internet<'a> {
+    pub source: Option<IpAddr>,
+    pub source_type: Option<IpType>,
+    pub destination: Option<IpAddr>,
+    pub destination_type: Option<IpType>,
+    pub protocol_name: &'static str,
+    pub payload_protocol: Option<TransportProtocol>,
+    pub payload: &'a [u8],
+    pub details: Option<InternetDetails<'a>>,
+}
+```
+
+Two design points deserve attention.
+
+**Addresses are optional.** Not because IP addresses are optional, but because
+not every L3 protocol has them in the IP sense. The flattened fields above are
+the *common denominator* of the layer — what a flow matrix needs.
+
+**`details` holds the full header.** Everything protocol-specific — TTL, flags,
+options, the ARP operation — lives there:
+
+```rust
+pub enum InternetDetails<'a> {
+    Ipv4(Ipv4Packet<'a>),
+    Ipv6(Ipv6Packet<'a>),
+    Arp(ArpPacket),
+}
+```
+
+`details` is ignored by `PartialEq`, `Hash` and serialization. Two packets of the
+same conversation differ in TTL and identification; treating those as part of the
+flow identity would give every packet its own bucket.
+
+## Supported protocols
+
+| Protocol | Notes |
+| --- | --- |
+| IPv4 | Full header, options, fragmentation flags |
+| IPv6 | Fixed header plus the extension-header chain |
+| ARP | Hardware/protocol types, operation, sender and target addresses |
+| Profinet | Industrial traffic reached by its own EtherType |
+
+### IPv4
+
+```rust
+pub struct Ipv4Packet<'a> {
+    pub version_ihl: u8,
+    pub dscp_ecn: u8,
+    pub total_length: u16,
+    pub identification: u16,
+    pub flags_fragment: u16,
+    pub ttl: u8,
+    pub protocol: u8,
+    pub header_checksum: u16,
+    pub source_addr: Ipv4Addr,
+    pub dest_addr: Ipv4Addr,
+    pub options: &'a [u8],
+    pub payload: &'a [u8],
+}
+```
+
+The packed fields keep their wire form and are read through accessors
+(`version()`, `ihl()`, `header_length()`), so the structure stays a faithful
+image of the header. `dscp_ecn` is decoded separately into the `Dscp` and `Ecn`
+types exported at the crate root.
+
+### IPv6
+
+IPv6 is not "IPv4 with longer addresses": the upper-layer protocol is at the end
+of an **extension header chain**, not in a fixed field. So `next_header` keeps
+what the fixed header said, while `transport_protocol` holds what the chain
+actually resolves to — and `payload` starts past the extension headers.
+
+`transport_protocol` is `None` when the chain ends with No Next Header (59), or
+when a Fragment extension header is present.
+
+### ARP
+
+ARP has no IP payload and no transport layer. Its addresses are exposed in the
+common `source`/`destination` fields when they are IP addresses, and the full
+frame — hardware type, protocol type, operation, sender and target hardware
+addresses — sits in `InternetDetails::Arp`.
+
+## Address classification
+
+Both endpoints are classified into an `IpType`:
+
+```rust
+pub enum IpType {
+    Private, Multicast, Loopback, Apipa,
+    LinkLocal, Ula, Public, Documentation, Unknown,
+}
+```
+
+This is cheap at parse time and expensive to redo later, which is why it is done
+here rather than left to callers. It is also what lets you separate
+"machine talking to the internet" from "machine talking to its own subnet"
+without a second pass.
+
+## Fragmentation: the deliberate `None`
+
+The crate does **not** perform IP reassembly. For a fragmented IPv4 packet — and
+for an IPv6 packet carrying a Fragment extension header — `payload_protocol` is
+set to `None`.
+
+This is not an omission, it is the point. The first fragment of a TCP segment
+looks like a parseable TCP header, and parsing it yields ports read from a
+datagram that is not complete. Reporting the L3 layer honestly and refusing to
+guess above it is the correct answer for a stateless parser.
+
+`protocol` in the IPv4 details still shows what the header claimed, so the
+information is not lost — it just does not drive L4 parsing.
+
+## Beyond TCP and UDP
+
+`payload_protocol` is a `TransportProtocol`, an enum covering the IANA IP
+protocol numbers, not just 6 and 17. Many of those variants have no ports and no
+application payload; they are represented so the layer can be *named* even when
+it cannot be decoded. Which ones are actually parsed is covered in
+[the transport chapter](./transport.md).
+
+## Parsing L3 on its own
+
+```rust
+// Dispatching: the caller knows what was announced.
+let internet = Internet::try_from_parts(ethertype, payload)?;
+
+// Probing: no context, tries each supported protocol.
+let internet = Internet::try_from(payload)?;
+```
+
+Prefer the first when you have the EtherType. It is the version that can tell a
+corrupt IPv4 header from an unsupported protocol — see
+[Data validation](./data_validation.md).

--- a/src/owned.md
+++ b/src/owned.md
@@ -1,0 +1,96 @@
+# Owned flows and serialization
+
+## Why an owned form exists
+
+`PacketFlow<'a>` borrows the buffer you passed to `parse`. That is what makes
+parsing cheap, and it is also what makes the flow unusable the moment the buffer
+goes away: you cannot store it in a cache, send it to another thread that
+outlives the capture loop, or hold it past the next `read_packet()`.
+
+The answer is an explicit conversion rather than a silent copy on every packet:
+
+```rust
+let owned = flow.to_owned(); // -> PacketFlowOwned
+```
+
+`PacketFlowOwned` has no lifetime. It mirrors the borrowed structure field for
+field:
+
+```rust
+pub struct PacketFlowOwned {
+    pub data_link: LinkLayerOwned,
+    pub internet: Option<InternetOwned>,
+    pub transport: Option<TransportOwned>,
+    pub application: Option<ApplicationOwned>,
+    pub inner: Option<Box<PacketFlowOwned>>,
+    pub corrupted: Option<CorruptedLayer>,
+}
+```
+
+Tunnels survive the conversion — `inner` is converted recursively — and so does
+the corruption report.
+
+## What the owned form drops
+
+**Payload bytes and the per-layer `details`.**
+
+This is intentional and worth understanding before you reach for `to_owned()`.
+The owned form keeps *flow identity*: link-layer information, addresses and their
+classification, protocol names, ports, application label. It does not keep the
+IPv4 options, the TCP flags, or a single byte of payload.
+
+```rust
+pub struct InternetOwned {
+    pub source_ip: Option<IpAddr>,
+    pub ip_source_type: Option<IpType>,
+    pub destination_ip: Option<IpAddr>,
+    pub ip_destination_type: Option<IpType>,
+    pub protocol: String,
+}
+```
+
+If you need TTLs or TCP options, read them from `details` **before** converting,
+while you still hold the borrowed flow.
+
+## Serialization
+
+Both forms implement `Serialize`, and — deliberately — they **serialize
+identically**. A pipeline can convert to owned at any stage without changing its
+output schema. Payload bytes are never serialized in either form.
+
+The schema introduced in 7.0 nests the link layer and uses stable tags:
+
+```json
+{
+  "data_link": {
+    "link_type": 1,
+    "network_protocol": { "kind": "ipv4" },
+    "link_kind": "ethernet",
+    "link_details": {
+      "destination_mac": "00:11:22:33:44:55",
+      "source_mac": "66:77:88:99:aa:bb",
+      "ethertype": "IPv4"
+    }
+  }
+}
+```
+
+Three things to note:
+
+- `link_type` is the **numeric** canonical LINKTYPE — it round-trips even for a
+  value this build cannot decode.
+- `link_kind` / `link_details` is a tagged union, so a consumer can branch on the
+  frame format without guessing from which fields are present.
+- MAC addresses serialize as `"aa:bb:cc:dd:ee:ff"` strings even though they are
+  `[u8; 6]` in memory, and EtherTypes serialize by name (`"IPv4"`).
+
+The upper layers are flattened into the object, which keeps the JSON close to the
+flat, one-row-per-packet shape that analysis tools want.
+
+## Equality and hashing
+
+Like the borrowed form, `PacketFlowOwned` derives `PartialEq`, `Eq` and `Hash`
+over the identity fields. Since the owned form has already dropped payloads and
+`details`, the two forms agree on what "the same flow" means — which is what
+makes it safe to key a long-lived `HashMap` on the owned version of a flow you
+matched while borrowed.

--- a/src/packet.md
+++ b/src/packet.md
@@ -1,11 +1,11 @@
 # Packet Structure and Parsing Approach
 
 ## What is a Packet?
-A network packet is a sequence of bytes transmitted over a network. Here’s an example of a raw packet in hexadecimal format:
+A network packet is a sequence of bytes transmitted over a network. Here's an example of a raw packet in hexadecimal format:
 
 ![Table](images/table.png)
 
-A **packet** is essentially a **list of bytes** representing network data.  
+A **packet** is essentially a **list of bytes** representing network data.
 For example:
 
 ```rust
@@ -14,8 +14,13 @@ let packet: &[u8] = &[0x00, 0x11, 0x22, 0x33, 0x44, 0x55, /* other bytes */];
 
 It is preferable to **reference** the packet (`&[u8]`) rather than copying it to avoid unnecessary memory usage and improve performance.
 
---- 
-## 🎨 Identifying Protocols in the Packet  
+This is not only a performance detail: it is the reason the whole parsed
+structure carries a lifetime. `PacketFlow<'a>` borrows the buffer you passed in,
+so no L2/L3/L4 payload is ever copied. When you need to keep a flow after the
+buffer is gone, you [convert it to an owned form](./owned.md) explicitly.
+
+---
+## 🎨 Identifying Protocols in the Packet
 
 Each protocol occupies a specific part of the packet. By analyzing the bytes, we can identify different layers.
 
@@ -23,53 +28,81 @@ Each protocol occupies a specific part of the packet. By analyzing the bytes, we
 
 ---
 
-## 🪆 Protocols are Nested (Like Russian Dolls)  
+## 🪆 Protocols are Nested (Like Russian Dolls)
 A network packet is structured as a series of encapsulated layers: each layer contains a protocol that encapsulates the next.
 ![Table](images/packetstruct.png)
 
+Some packets take this literally and carry **a whole other packet** inside their
+payload. That is a tunnel, and it produces several flow levels from a single
+wire packet — see [Tunnels](./tunnels.md).
+
 ---
 
-## `ParsedPacket` Layered Structure
+## Layered Structure
 Once parsed, a packet is structured into **four layers**, following the OSI model:
 ![Table](images/PacketParser_proto.png)
 
 
-The **Data Link Layer** is always present, while the others depend on the packet type.
+The **link layer** is always present, while the others depend on the packet type
+— and on whether their bytes made sense.
 
 ---
 
-## 🔗 How Layers Interact with Addresses and Entry/Exit Points  
+## 🔗 How Layers Interact with Addresses and Entry/Exit Points
 Each layer contains specific information to identify **source and destination addresses**.
 ![Table](images/PacketParser_endpoint.png)
 
+Those fields are what defines the *identity* of a flow. `PacketFlow` takes that
+seriously: its `PartialEq`, `Eq` and `Hash` implementations compare addresses,
+protocols and ports, and deliberately **ignore the payloads**. Two packets of the
+same conversation carrying different data therefore compare equal and hash
+identically, which is exactly what you want when building a flow matrix.
+
 ---
 
-## 🧐 Detailed Breakdown of Parsed Structures  
+## 🧐 Detailed Breakdown of Parsed Structures
 Each protocol has its own structure with unique fields.
 
 ![Table](images/PacketParser_struct.png)
 
 ---
-## Parsing Strategy Based on Payloads  
- 
+## Parsing Strategy Based on Payloads
+
 Parsing is determined by the payloads extracted at each stage.
 
 ![Table](images/PacketParser_parsing.png)
+
+Each layer parses the **payload of the layer below it**, and hands its own
+payload to the layer above. The link layer exposes it as `network_payload()`,
+the internet layer as `payload`, the transport layer as `payload`.
+
 ## Independent Layer Parsing
 
-Each layer must be **parsed independently** from the others.  
-We do **not** use information from one layer to infer details about another.  
+Each layer must be **parsed independently** from the others.
+We do **not** use information from one layer to infer details about another.
 
 ### **Why?**
 - **Security:** Attackers can manipulate packet fields (e.g., changing port numbers).
 - **Flexibility:** Some protocols do not strictly follow conventional port assignments.
 - **Reliability:** Parsing should be based on raw data, not assumptions.
 
-For example, **we do not parse an application-layer protocol based on the transport-layer port number**.  
+For example, **we do not parse an application-layer protocol based on the transport-layer port number**.
 Just because a packet has **port 80** does not mean it contains **HTTP**—it could be anything.
 
+### Where that rule bends, and why
 
+Experience with real captures forced one nuance. A few application protocols
+have a *weak signature*: a handful of ASCII commands, or a header short enough
+that random bytes match it. Probing those blindly labels unrelated traffic.
 
+So detection now has two regimes:
 
+- **Strong signature** → probed on content, on any port (TLS, DNS, QUIC,
+  S7Comm over TCP…).
+- **Weak signature** → parser validation **and** the protocol's standard control
+  port (FTP on TCP/21, SMTP on 25/587, NNTP on 119, DHCPv6, SNMP…).
 
-
+The rule "never infer a layer from another layer" still holds for *decoding*.
+The port is used only as a **guard against false positives**, never as the sole
+reason to claim a protocol. Details are in the
+[application layer chapter](./application.md).

--- a/src/packet_flow.md
+++ b/src/packet_flow.md
@@ -1,0 +1,106 @@
+# The `PacketFlow` structure
+
+`PacketFlow` is what a parse returns. It is the structure this book used to call
+`ParsedPacket`, redesigned around one observation: **real captures are partial**.
+A packet whose EtherType is unknown to us is not an invalid packet, and refusing
+to return anything for it throws away the perfectly valid MAC addresses we did
+read.
+
+## The shape
+
+```rust
+pub struct PacketFlow<'a> {
+    /// Link layer (mandatory), tagged with its canonical LINKTYPE.
+    pub data_link: LinkLayer<'a>,
+
+    /// Internet layer (optional).
+    pub internet: Option<Internet<'a>>,
+
+    /// Transport layer (optional).
+    pub transport: Option<Transport<'a>>,
+
+    /// Application layer (optional, best-effort).
+    pub application: Option<Application>,
+
+    /// Packet carried inside a tunnel, recursively.
+    pub inner: Option<Box<PacketFlow<'a>>>,
+
+    /// Set when a recognized layer carried invalid bytes.
+    pub corrupted: Option<CorruptedLayer>,
+}
+```
+
+Read as a tree:
+
+```text
+PacketFlow<'a>
+├── data_link:   LinkLayer<'a>              (mandatory — Ethernet, SLL, SLL2, RAW)
+├── internet:    Option<Internet<'a>>       source / destination / protocol_name
+│                                           / payload_protocol / payload / details
+├── transport:   Option<Transport<'a>>      protocol / source_port / destination_port
+│                                           / payload / details
+├── application: Option<Application>        application_protocol: &'static str
+├── inner:       Option<Box<PacketFlow<'a>>>  packet carried inside a tunnel
+└── corrupted:   Option<CorruptedLayer>     set when a recognized layer held
+                                            invalid bytes
+```
+
+Only `data_link` is mandatory. That asymmetry is the whole design.
+
+## Fail-closed below, fail-soft above
+
+There is exactly **one** thing that can fail a parse: the link layer.
+
+- The LINKTYPE has no decoder in this build → `Err(ParseError::UnsupportedLinkType)`.
+- The link header itself is unreadable → `Err(ParseError::InvalidLinkLayer(..))`.
+
+Above the link layer, nothing fails. An unknown IP protocol number, a truncated
+TCP header, an application payload we cannot classify — none of these produce an
+`Err`. They produce a `None` on that layer, and the layers *below* stay filled.
+
+## Three outcomes, and why you must not confuse them
+
+For every optional layer there are three distinct states, and collapsing them is
+the most common way to misread a capture:
+
+| `internet` | `corrupted` | Meaning |
+| --- | --- | --- |
+| `Some(..)` | `None` | The layer was recognized and decoded. |
+| `None` | `None` | The protocol is **not supported**; nothing above it could be reached. |
+| `None` | `Some(..)` | The layer **was recognized** but carried invalid bytes. |
+
+`CorruptedLayer` names which layer broke and carries a human-readable message:
+
+```rust
+pub struct CorruptedLayer {
+    pub layer: CorruptedLayerKind, // Internet | Transport
+    pub error: String,
+}
+```
+
+The distinction matters operationally. "We do not decode LLDP" and "this IPv4
+header is malformed" are the same `internet: None` to a careless reader, but the
+first is a gap in the crate and the second is a finding about the traffic.
+
+This is also why the internal parsing path dispatches on the announced protocol
+instead of probing. `Internet::try_from(&[u8])` probes every supported protocol
+and therefore *cannot* tell a corrupt packet from an unknown one;
+`Internet::try_from_parts(ethertype, payload)` knows the EtherType said "IPv4"
+and can report the parse error. See
+[the data validation chapter](./data_validation.md).
+
+## Flow identity: equality and hashing
+
+`PartialEq`, `Eq` and `Hash` compare **flow identity** — addresses, protocols,
+ports — and deliberately ignore raw payloads and the per-layer `details`. Two
+packets from the same conversation with different content compare equal and hash
+to the same value, so a `HashMap<PacketFlow, Counter>` builds a conversation
+matrix directly.
+
+## Lifetimes
+
+`PacketFlow<'a>` borrows the buffer you passed to `parse`. It cannot outlive it,
+cannot cross a thread boundary that outlives it, and cannot be stored in a
+long-lived cache. When you need any of that, call
+[`to_owned()`](./owned.md) — an explicit, visible copy rather than a silent one
+on every packet.

--- a/src/performance.md
+++ b/src/performance.md
@@ -1,0 +1,91 @@
+# Performance and benchmarks
+
+## The `parse_timing` feature
+
+Per-layer timing is not in the normal path. Reading a clock four times per packet
+would show up in the numbers it is supposed to measure, so it lives behind a
+feature flag:
+
+| Feature | Effect |
+| --- | --- |
+| `doc-diagrams` | Enables Rustdoc diagrams through `aquamarine` |
+| `parse_timing` | Exposes `ParseTiming`, `parse_timed` and `PacketFlow::try_from_timed` |
+
+```rust
+use packet_parser::{LinkType, parse_timed, timing::ParseTiming};
+
+let mut timing = ParseTiming::default();
+let flow = parse_timed(LinkType::ETHERNET, &packet, &mut timing)?;
+
+println!("L2={}ns L3={}ns L4={}ns L7={}ns total={}ns",
+    timing.l2_ns,
+    timing.l3_ns,
+    timing.l4_ns,
+    timing.l7_ns,
+    timing.total_ns,
+);
+```
+
+```bash
+cargo test --features parse_timing
+```
+
+When the feature is off, `ParseTiming` is a zero-sized type and the timing calls
+compile away — the measured path and the production path are the same code, not
+two implementations that can drift.
+
+Two limits to keep in mind: the timed path is for measurement and should not be
+treated as the standard parsing path, and it does not yet recursively measure the
+`inner` flows produced by [tunnel parsing](./tunnels.md).
+
+## `tools/verbench`: comparing versions
+
+The main benchmark harness compares published crate versions from crates.io
+against the local working copy, on a fixed reference packet after warmup, and
+reports average `l2_ns`, `l3_ns`, `l4_ns`, `l7_ns` and `total_ns`.
+
+```bash
+tools/verbench/run.sh          # full run → perf_by_version.json + .html
+python3 tools/verbench/report.py   # regenerate only the HTML from existing JSON
+xdg-open perf_by_version.html
+```
+
+The HTML report is standalone: it opens directly in a browser and needs no
+Docker, Postgres, Grafana or CDN.
+
+Read those numbers as **trends between versions on the same machine**, not as
+universal absolute latency claims. A refactor that moves `total_ns` from 900 to
+700 on your laptop is a real signal; the 700 itself is not a promise.
+
+## The optional PCAP pipeline
+
+The workspace also contains `benchmark_db`, a binary that parses local PCAP files
+and writes JSONL events:
+
+```bash
+cargo run -p benchmark_db --release
+```
+
+Each event contains `run_id`, `crate_code`, `pcap`, the packet index, the packet
+hash, the total duration, and the OSI timings when `parse_timing` is enabled.
+Output goes to:
+
+```text
+~/.local/share/packet_parser_bench/jsonl/
+```
+
+The optional `docker-compose.yml` pipeline ingests those files into Postgres and
+displays them in Grafana. It is entirely optional — the standalone `verbench`
+HTML report does not need it.
+
+## Known limitations
+
+Stated plainly, because each is a deliberate trade against statefulness:
+
+- **No TCP reassembly.** Segments are parsed individually.
+- **No IP reassembly.** Fragments set `payload_protocol: None` rather than
+  parsing L4 from an incomplete datagram.
+- **Application detection is heuristic and best-effort.** See
+  [the application chapter](./application.md).
+- **The `parse_timing` path is for measurement**, not the standard path.
+- **Timed parsing does not recurse into `inner` flows.**

--- a/src/the_packet_parser_crate.md
+++ b/src/the_packet_parser_crate.md
@@ -1,12 +1,17 @@
 # The Packet Parser Crate
 
-*By Cyprien Avico*  
+*By Cyprien Avico*
 
-[www.linkedin.com/in/cyprien-avico](https://www.linkedin.com/in/cyprien-avico)  
+[www.linkedin.com/in/cyprien-avico](https://www.linkedin.com/in/cyprien-avico)
 
-The repo of the crate: [GitHub - Packet Parser](https://github.com/Akmot9/Packet-parser)  
-The crate link: *coming soon...*  
+The repo of the crate: [GitHub - Packet Parser](https://github.com/Akmot9/Packet-parser)
+The crate: [crates.io/crates/packet_parser](https://crates.io/crates/packet_parser)
+The API reference: [docs.rs/packet_parser](https://docs.rs/packet_parser)
 
-This is not a Rust doc. This is a documentation on how I personally parse packets.  
+This book targets **`packet_parser` 10.0.0**.
 
-Feel free to criticize, do a PR, or send me a message on LinkedIn.  
+This is not a Rust doc. This is a documentation on how I personally parse packets.
+The Rust doc tells you *what* the API is; this book tells you *why* it looks like
+that, and what happens to a packet between the wire and the returned structure.
+
+Feel free to criticize, do a PR, or send me a message on LinkedIn.

--- a/src/transport.md
+++ b/src/transport.md
@@ -1,1 +1,130 @@
 # Transport
+
+The transport layer (L4) is parsed from the internet layer's `payload`,
+dispatching on its `payload_protocol`.
+
+## The `Transport` structure
+
+```rust
+pub struct Transport<'a> {
+    pub protocol: TransportProtocol,
+    pub source_port: Option<u16>,
+    pub destination_port: Option<u16>,
+    pub payload: Option<&'a [u8]>,
+    pub details: Option<TransportDetails<'a>>,
+}
+```
+
+Same split as L3: the flattened fields are the flow identity, and the full
+decoded header lives in `details`:
+
+```rust
+pub enum TransportDetails<'a> {
+    Tcp(TcpPacket<'a>),
+    Udp(UdpPacket<'a>),
+    Icmp(IcmpPacket<'a>),
+    Icmpv6(Icmpv6Packet<'a>),
+}
+```
+
+The enum is `#[non_exhaustive]`, so adding a decoded protocol stays a minor
+version bump. Match with a `_` arm.
+
+Ports are `Option` because `TransportProtocol` covers the whole IANA protocol
+number space, and most of those protocols have no ports at all.
+
+## What is decoded
+
+### TCP
+
+```rust
+pub struct TcpHeader<'a> {
+    pub source_port: u16,
+    pub destination_port: u16,
+    pub sequence_number: u32,
+    pub acknowledgment_number: u32,
+    pub data_offset: u8,
+    pub reserved: u8,
+    pub ns: bool, pub cwr: bool, pub ece: bool, pub urg: bool,
+    pub ack: bool, pub psh: bool, pub rst: bool, pub syn: bool, pub fin: bool,
+    pub window_size: u16,
+    pub checksum: u16,
+    pub urgent_pointer: u16,
+    pub options: &'a [u8],
+}
+```
+
+Every flag is a named `bool` rather than a bitfield the caller has to mask
+themselves. The data offset is validated before it is used to slice options and
+payload — an unchecked one is an out-of-bounds read waiting to happen.
+
+**No TCP reassembly.** Each segment is parsed on its own. An application message
+split across segments is not reconstructed, which is what keeps the crate
+stateless and per-packet.
+
+### UDP
+
+```rust
+pub struct UdpPacket<'a> {
+    pub source_port: u16,
+    pub destination_port: u16,
+    pub length: u16,
+    pub checksum: u16,
+    pub payload: &'a [u8],
+}
+```
+
+### ICMPv4
+
+Reached through **IP protocol number 1, never through probing**. Decoded
+messages:
+
+- Echo request / reply — identifier, sequence, and the echoed data.
+- The error reports that quote the original datagram: destination unreachable,
+  redirect, time exceeded, parameter problem — with their four type-dependent
+  bytes and the quoted datagram.
+
+### ICMPv6
+
+Reached through **IPv6 next header 58**. Type numbering is *disjoint* from
+ICMPv4 — 128 is an echo request there, 8 is undefined — so the two have separate
+parsers rather than a shared one with special cases. Decoded messages:
+
+- Echo request / reply.
+- The error reports that quote the invoking packet.
+- Neighbor discovery (RFC 4861): router solicitation and advertisement — the
+  latter with its hop limit, M/O flags, router lifetime, reachable time and
+  retransmit timer — plus neighbor solicitation and advertisement with their
+  target address and R/S/O flags.
+
+### Why ICMP keeps `payload: None`
+
+Neither ICMP version carries an application layer. Their decoded content is
+exposed through `TransportDetails::Icmp` / `Icmpv6`, and `payload` stays
+deliberately `None`.
+
+The reason is defensive: if ICMP bytes were exposed as a transport payload, they
+would be submitted to application detection, which would happily label a quoted
+datagram as some application protocol. Withholding the payload makes that
+impossible by construction rather than by a special case in the detector.
+
+## Beyond TCP/UDP/ICMP
+
+`TransportProtocol::from_u8` maps the IANA protocol numbers, so a flow carrying
+GRE, ESP or SCTP is **named** even though it is not decoded. In that case
+`details` is `None`, ports are `None`, and the layer still tells you what the IP
+header announced.
+
+## Parsing L4 on its own
+
+```rust
+// Dispatching: the protocol number is known.
+let transport = Transport::try_from_parts(payload_protocol, payload)?;
+
+// Probing: no context.
+let transport = Transport::try_from(payload)?;
+```
+
+As at L3, prefer `try_from_parts`: it is what allows a malformed TCP header to be
+reported as `corrupted: Transport` instead of vanishing into an indistinguishable
+`None`.

--- a/src/tunnels.md
+++ b/src/tunnels.md
@@ -1,0 +1,74 @@
+# Tunnels
+
+Some packets carry **a whole other packet** inside their payload. A layered,
+single-level parser only sees the outer flow and misses the real conversation
+nested inside — which, in a wireless deployment, is *every* conversation.
+
+## The `inner` field
+
+```rust
+pub struct PacketFlow<'a> {
+    // …
+    pub inner: Option<Box<PacketFlow<'a>>>,
+}
+```
+
+When a tunnel is detected, its headers are peeled and the encapsulated packet is
+re-parsed as a full `PacketFlow`, recursively. One wire packet then yields
+several flow levels: the outer tunnel, then the conversation(s) inside it.
+
+`flatten()` walks the chain from outermost to innermost:
+
+```rust
+let flow = parse(LinkType::ETHERNET, &packet)?;
+
+for level in flow.flatten() {
+    println!("{:?} -> {:?}", level.internet, level.transport);
+}
+```
+
+The outer flow is index 0 and is always present, so `flatten()` never returns an
+empty vector.
+
+## What is supported today
+
+One path, end to end:
+
+```text
+Ethernet
+└── IP / UDP port 5247
+    └── CAPWAP-Data (RFC 5415)
+        └── IEEE 802.11
+            └── LLC / SNAP
+                └── inner L3 packet → inner PacketFlow
+```
+
+The tunnel is recognized **at the transport layer** (UDP/5247), its name is
+reported as the outer flow's application protocol, and the inner packet gets an
+honest IEEE 802.11 link layer — not a fabricated Ethernet header. That is the
+same principle as [the LINKTYPE rule](./link_types.md): the inner frame really is
+802.11, so it is presented as 802.11, and `as_ieee80211()` is how you read it.
+
+## The depth guard
+
+```rust
+pub(crate) const MAX_TUNNEL_DEPTH: u8 = 4;
+```
+
+Malformed or hostile traffic can claim endless encapsulation. Recursion stops at
+depth 4 — the outer flow being depth 0 — so a crafted packet cannot turn a parse
+into an unbounded allocation loop.
+
+## Growing the list
+
+`detect_inner` is the single extension point. VXLAN, GRE, GTP-U and IP-in-IP
+plug in the same way: recognize the encapsulation from the transport layer,
+return the tunnel name and the byte range of the inner packet, and let
+`PacketFlow` re-parse it.
+
+## Known limit
+
+Tunnel recursion boxes the inner flow, so it allocates — one of the documented
+exceptions to the zero-copy rule. And timed parsing does not yet recursively
+measure `inner` flows; the timings you get describe the outer parse only (see
+[Performance](./performance.md)).


### PR DESCRIPTION
## Why

The book still described a `ParsedPacket` that either parsed a whole packet or failed, assumed Ethernet everywhere, and left `network.md`, `transport.md` and `application.md` as one-line stubs.

The crate has since moved to `PacketFlow`, an explicit caller-supplied LINKTYPE, tunnels, owned flows and 24 application parsers. This brings the book in line with `Akmot9/Packet-parser` at 10.0.0.

## What changed

The book goes from 8 to 15 chapters. `src/crate_struct.md` (an unreferenced two-line stub) is removed.

**New chapters**

- **Getting started** — install, `parse(LinkType, &[u8])`, `is_supported`, the API table, the runnable examples.
- **The `PacketFlow` structure** — the shape, fail-closed L2 / fail-soft above, and the three distinct outcomes: layer present, layer `None` (unsupported), layer `None` + `corrupted` (recognized but invalid bytes).
- **Link types** — `LinkType`, the supported LINKTYPE table, per-format notes for SLL v1/v2 and RAW IP, the generic `LinkLayer` accessors, and why `PacketFlow::try_from(&[u8])` silently fabricates MAC addresses on a non-Ethernet capture.
- **Tunnels** — `inner`, `flatten()`, the CAPWAP → 802.11 → LLC/SNAP path, and the depth guard.
- **Owned flows and serialization** — `to_owned()`, what it drops (payloads and `details`), and the 7.0 JSON schema.
- **Performance and benchmarks** — the `parse_timing` feature, `tools/verbench`, `benchmark_db`, and the known limitations.
- **Adding a protocol** — the repository method, the three detection paths, and the pre-commit checklist.

**Filled in from stubs**

- **Internet** — the `Internet` struct, IPv4/IPv6/ARP/Profinet, `IpType` classification, and why fragmentation sets `payload_protocol: None`.
- **Transport** — the `Transport` struct, TCP/UDP/ICMP/ICMPv6, and why ICMP keeps `payload: None`.
- **Application** — classification rather than decode, the protocol list, and the strong-signature vs port-guarded detection regimes.

**Rewritten**

- **Introduction**, **Packet**, **Data link**, **Data validation** — updated to the current API; all existing images kept.
- **Title page** and repo **readme** — crates.io/docs.rs links, current version, and the trailing LLM prompt artifact removed from the readme.

## Verification

`mdbook build` passes with **mdbook 0.4.36**, the version pinned by `.github/workflows` — not the latest, which rejects the `multilingual` field in `book.toml`. `book.toml` and the workflow are untouched.

All `SUMMARY.md` entries and inter-chapter links resolve to existing files.

## Not touched

`src/test` is a leftover scratch file, unreferenced by the SUMMARY. Left in place — say the word and I'll remove it.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J7YSN5ur4Vi7ZbuaaMJWEj)_